### PR TITLE
fix: use multisheet query for book sidenav json

### DIFF
--- a/blocks/side-nav/side-nav.js
+++ b/blocks/side-nav/side-nav.js
@@ -31,6 +31,9 @@ const template = () => html`
  * @param {HTMLDivElement} block
  */
 export default async function decorate(block) {
+  // N rows
+  // 1st row is link to book currently being viewed
+  // 2..N row are links to additional books, can be loaded lazily
   const link = block.querySelector('a');
   const path = link ? link.getAttribute('href') : block.textContent.trim();
 

--- a/blocks/side-nav/side-nav.js
+++ b/blocks/side-nav/side-nav.js
@@ -7,7 +7,7 @@ import { assertValidDocsURL, html } from '../../scripts/scripts.js';
 async function loadNavJSON(path) {
   assertValidDocsURL(path);
 
-  const resp = await fetch(`${path}.json`);
+  const resp = await fetch(`${path}.json?sheet=default&sheet=chapters&sheet=topics`);
   if (!resp.ok) return null;
   try {
     return await resp.json();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -123,11 +123,12 @@ function buildBookBlocks(main) {
   if (main !== docMain) return;
 
   const bookName = getMetadata('book-name') || 'book';
-  const bookPaths = getMetadata('books').split(',').map((s) => s.trim());
+  const bookPath = getMetadata('book');
+  const additionalBookPaths = (getMetadata('additional-books') || '').split(',').map((s) => s.trim()).filter((s) => !!s);
   const origin = DOCS_ORIGINS[getEnv()];
   const docHref = `${origin}${window.location.pathname}`; // matches article path
   const navHref = (path) => `${origin}${path}/${bookName}`; // points to book in docs repo, no extension
-  const navHrefs = bookPaths.map(navHref);
+  const navHrefs = [navHref(bookPath), ...additionalBookPaths.map(navHref)];
 
   const articleSection = buildArticleBlock(main, docHref);
   buildSideNavBlock(articleSection, navHrefs);


### PR DESCRIPTION
- update fetch in sidenav block to use multisheet query
- update metadata to use `book` and `additional-books`

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/admin-guide-pcee/welcome/welcome
- After: https://maxed-book-json--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/admin-guide-pcee/welcome/welcome
