### PR TITLE
fix: use docs path prefix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--<repo>--<owner>.hlx.page/
-- After: https://<branch>--<repo>--<owner>.hlx.page/
+- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
+- After: https://<branch>--prisma-cloud-docs-website--hlxsites.hlx.page/

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -17,6 +17,7 @@ import {
 
 const range = document.createRange();
 
+const PATH_PREFIX = '/prisma/prisma-cloud';
 const LCP_BLOCKS = ['article']; // add your LCP blocks to the list
 window.hlx.RUM_GENERATION = 'prisma-cloud-docs-website'; // add your RUM generation information here
 
@@ -149,7 +150,8 @@ function buildBookBlocks(main) {
   const bookPath = getMetadata('book');
   const additionalBookPaths = (getMetadata('additional-books') || '').split(',').map((s) => s.trim()).filter((s) => !!s);
   const origin = DOCS_ORIGINS[getEnv()];
-  const docHref = `${origin}${window.location.pathname}`; // matches article path
+  const docPath = `${PATH_PREFIX}/docs${window.location.pathname.substring(PATH_PREFIX.length)}`;
+  const docHref = `${origin}${docPath}`;
   const navHref = (path) => `${origin}${path}/${bookName}`; // points to book in docs repo, no extension
   const navHrefs = [navHref(bookPath), ...additionalBookPaths.map(navHref)];
 


### PR DESCRIPTION

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/30-xx/admin-guide-pcee/install/install-defender/auto-defend-host
- After: https://maxed-path-fix--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/30-xx/admin-guide-pcee/install/install-defender/auto-defend-host
