### PR TITLE
font display swap with fallback

### DIFF
--- a/blocks/procedure/procedure.css
+++ b/blocks/procedure/procedure.css
@@ -15,7 +15,7 @@
 }
 
 .procedure ol.steps li.step::before {
-  font-family: "HCo Decimal", Lato, "Helvetica Neue", Helvetica, Arial, sans-serif, FontAwesome;
+  font-family: 'HCo Decimal', 'HCo Decimal Fallback', Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif, FontAwesome;
   counter-increment: step-counter;
   content: "STEP " counter(step-counter) " \f101";
   color: #fa582d;

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -22,7 +22,7 @@
     src: url('/fonts/decimal/Decimal-Book-Pro.woff2') format('woff2');
     font-weight: 400;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -30,7 +30,7 @@
     src: url('/fonts/decimal/Decimal-BookItalic-Pro.woff2') format('woff2');
     font-weight: 400;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -38,7 +38,7 @@
     src: url('/fonts/decimal/Decimal-Medium-Pro_Web.woff2') format('woff2');
     font-weight: 500;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -46,7 +46,7 @@
     src: url('/fonts/decimal/Decimal-MediumItalic-Pro.woff2') format('woff2');
     font-weight: 500;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -54,7 +54,7 @@
     src: url('/fonts/decimal/Decimal-Semibold-Pro_Web.woff2') format('woff2');
     font-weight: 600;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -62,7 +62,7 @@
     src: url('/fonts/decimal/Decimal-SemiboldItalic-Pro.woff2') format('woff2');
     font-weight: 600;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 /* @font-face {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,6 +10,18 @@
  * governing permissions and limitations under the License.
  */
 
+@font-face {
+  font-family: 'HCo Decimal Fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Arial');
+  ascent-override: 78.87%;
+  descent-override: 16.43%;
+  line-gap-override: 4.03%;
+  size-adjust: 121.72%;
+}
+
+
 :root {
   /* colors */
   --link-color: #035fe6;
@@ -22,7 +34,7 @@
   --footer-background-color: #1f2b35;
 
   /* fonts */
-  --body-font-family: 'HCo Decimal', lato, 'Helvetica Neue', helvetica, arial, sans-serif;
+  --body-font-family: 'HCo Decimal', 'HCo Decimal Fallback', lato, 'Helvetica Neue', helvetica, arial, sans-serif;
   --heading-font-family: var(--body-font-family);
   --fixed-font-family: menlo, monaco, consolas, "Courier New", monospace;
 


### PR DESCRIPTION
Fallback font (generated with https://github.com/pixel-point/fontpie):
<img width="1496" alt="Screenshot 2023-06-08 at 14 16 51" src="https://github.com/hlxsites/prisma-cloud-docs-website/assets/6012307/9693b93b-b5cb-4fb7-838b-4c098d24d973">


Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/access-control/rbac
- After: https://fonts-swap--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/access-control/rbac
