### PR TITLE
hide versions selector on unversioned books, change book sheet

### DIFF
--- a/prisma/prisma-cloud/blocks/article/article.js
+++ b/prisma/prisma-cloud/blocks/article/article.js
@@ -231,16 +231,20 @@ export default async function decorate(block) {
       const prevTopic = book.topics.data[topicIndex - 1];
       const nextTopic = book.topics.data[topicIndex + 1];
 
-      if (prevTopic.chapter === currentTopic.chapter) {
-        block.querySelector('.prev').href = `${href.join('/')}/${prevTopic.key.replaceAll('_', '-')}`;
-      } else {
-        block.querySelector('.prev').href = `${href.slice(0, -1).join('/')}/${prevTopic.chapter}/${prevTopic.key.replaceAll('_', '-')}`;
+      if (prevTopic) {
+        if (prevTopic.chapter === currentTopic.chapter) {
+          block.querySelector('.prev').href = `${href.join('/')}/${prevTopic.key.replaceAll('_', '-')}`;
+        } else {
+          block.querySelector('.prev').href = `${href.slice(0, -1).join('/')}/${prevTopic.chapter}/${prevTopic.key.replaceAll('_', '-')}`;
+        }
       }
 
-      if (nextTopic.chapter === currentTopic.chapter) {
-        block.querySelector('.next').href = `${href.join('/')}/${nextTopic.key.replaceAll('_', '-')}`;
-      } else {
-        block.querySelector('.next').href = `${href.slice(0, -1).join('/')}/${nextTopic.chapter}/${nextTopic.key.replaceAll('_', '-')}`;
+      if (nextTopic) {
+        if (nextTopic.chapter === currentTopic.chapter) {
+          block.querySelector('.next').href = `${href.join('/')}/${nextTopic.key.replaceAll('_', '-')}`;
+        } else {
+          block.querySelector('.next').href = `${href.slice(0, -1).join('/')}/${nextTopic.chapter}/${nextTopic.key.replaceAll('_', '-')}`;
+        }
       }
     });
   }

--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.css
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.css
@@ -363,7 +363,6 @@
 
     .pan-sidenav .banner {
         display: flex;
-        justify-content: flex-end;
         padding-bottom: var(--sidebar-banner-padding);
     }
 

--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.js
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.js
@@ -78,11 +78,12 @@ const TEMPLATE = /* html */`
  * @param {Element} wrapper
  */
 function initVersionDropdown(wrapper) {
-  const versionsDropdown = wrapper.querySelector('.version-dropdown');
+  const versionsContainer = wrapper.querySelector('.sidenav .banner .versions');
+  const versionsDropdown = versionsContainer.querySelector('.version-dropdown');
   const curVersionKey = getMetadata('version');
 
   if (!store.product || curVersionKey === 'not-applicable') {
-    versionsDropdown.remove();
+    versionsContainer.remove();
     return;
   }
 
@@ -223,7 +224,10 @@ function localize(block) {
     const ph = await getPlaceholders();
     block.querySelector('.locale-toc-form-input').placeholder = ph.tocFormInput;
     block.querySelector('.locale-book-last-updated').textContent = ph.bookLastUpdated;
-    block.querySelector('.locale-book-current-version').textContent = ph.bookCurrentVersion;
+    const curVersion = block.querySelector('.locale-book-current-version');
+    if (curVersion) {
+      curVersion.textContent = ph.bookCurrentVersion;
+    }
     block.querySelector('.locale-toc-title').textContent = ph.tocTitle;
     block.querySelector('.locale-toc-filter').textContent = ph.tocFilter;
 

--- a/prisma/prisma-cloud/scripts/scripts.js
+++ b/prisma/prisma-cloud/scripts/scripts.js
@@ -161,8 +161,7 @@ const store = new (class {
 
     const makeBookHref = (path) => `${this.docsOrigin}${path}/book`;
 
-    let mainBookTitle;
-    this.allBooks = (getMetadata('additional-books') || '').split(';;').map((s) => s.trim()).filter((s) => !!s)
+    this.allBooks = (getMetadata('all-books') || '').split(';;').map((s) => s.trim()).filter((s) => !!s)
       .map((data) => {
         const [path, title] = data.split(';');
 
@@ -172,8 +171,8 @@ const store = new (class {
         };
 
         if (path === this.bookPath) {
-          mainBookTitle = title;
           book.mainBook = true;
+          this.mainBook = book;
         }
 
         return book;
@@ -181,11 +180,6 @@ const store = new (class {
 
     // exclude main book from additionalBooks
     this.additionalBooks = this.allBooks.filter((b) => !b.mainBook);
-
-    this.mainBook = {
-      title: mainBookTitle,
-      href: makeBookHref(this.bookPath),
-    };
   }
 
   getAllBookLinks() {


### PR DESCRIPTION
Fix #49

- use `all-books` for name of metadata entry instead of `additional-books`, since it in fact includes all books

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/is-notifications/notifications/notifications
- After: https://maxed-fixes--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/is-notifications/notifications/notifications
