### PR TITLE
fix sidenav active link color (fixes #91)

### DIFF
--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.css
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.css
@@ -346,7 +346,7 @@
     border-radius: 4px;
 }
 
-.pan-sidenav .toc-books li.current > div > a:visited {
+.pan-sidenav .toc-books li.current > div > a {
     color: #f4f4f2;
 }
 


### PR DESCRIPTION
Fix #91 

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/public-sector/release-findings/release-findings
- After: https://sidenav-active-link-color--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/public-sector/release-findings/release-findings
