### PR TITLE
fix: book page layout shift

### DIFF
--- a/prisma/prisma-cloud/blocks/breadcrumbs/breadcrumbs.css
+++ b/prisma/prisma-cloud/blocks/breadcrumbs/breadcrumbs.css
@@ -2,6 +2,11 @@ main .breadcrumbs-container {
     padding: 0;
     position: relative;
     width: 100vw;
+    visibility: hidden;
+}
+
+main .breadcrumbs-container[data-section-status="loaded"] {
+    visibility: visible;
 }
 
 .landing-product .breadcrumbs-container {

--- a/prisma/prisma-cloud/scripts/scripts.js
+++ b/prisma/prisma-cloud/scripts/scripts.js
@@ -696,13 +696,15 @@ export function addFavIcon(href) {
  */
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
+
+  loadHeader(doc.querySelector('header'));
+
   await loadBlocks(main);
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadHeader(doc.querySelector('header'));
   loadFooter(doc.querySelector('footer'));
 
   updateLinksWithBranch(doc);
@@ -728,6 +730,26 @@ async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();
+
+  // TODO refactor with updateLinksWithBranch function
+  if (document.body.classList.contains('book')) {
+    // Watches for section and block status loaded
+    const statusObserver = new MutationObserver(() => {
+      const ready = [...document.body.querySelectorAll('[data-section-status]')].every((element) => element.dataset.sectionStatus === 'loaded')
+        && [...document.body.querySelectorAll('[data-block-status]')].every((element) => element.dataset.blockStatus === 'loaded');
+
+      if (ready) {
+        document.querySelector('footer').classList.add('appear');
+        statusObserver.disconnect();
+      }
+    });
+
+    statusObserver.observe(document.body, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-section-status', 'data-block-status'],
+    });
+  }
 }
 
 loadPage();

--- a/prisma/prisma-cloud/styles/styles.css
+++ b/prisma/prisma-cloud/styles/styles.css
@@ -112,6 +112,14 @@ body main {
   max-width: var(--max-width);
 }
 
+.book footer {
+  display: none;
+}
+
+.book footer.appear {
+  display: block;
+}
+
 header.loaded {
   background: transparent;
 }
@@ -340,6 +348,15 @@ main .section.full-width > div {
   .container {
     width: 1200px;
   }
+}
+
+/* breadcrumbs */
+main .breadcrumbs-container {
+  visibility: hidden;
+}
+
+main .breadcrumbs-container[data-section-status="loaded"] {
+  visibility: visible;
 }
 
 /* book template */


### PR DESCRIPTION
* load breadcrumb earlier
* hide footer until main content is loaded

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/install/getting-started
- After: https://book-layout-shift--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/install/getting-started
