### PR TITLE
fix: sidenav follow book order defined in metadata sheet

### DIFF
--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.js
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.js
@@ -572,32 +572,21 @@ function renderTOC(container, book, expand, replace) {
 function initAdditionalBooks(block, container) {
   const mainBook = container.querySelector('ul');
 
-  let afterMainBook = false;
-  let neighbor;
+  // insert books in order defined in metadata
   store.allBooks.forEach((book) => {
-    if (book.mainBook) {
-      afterMainBook = true;
-    } else {
-      // insert books in order defined in metadata
-      const position = afterMainBook ? 'afterend' : 'beforebegin';
-      neighbor = afterMainBook ? neighbor || mainBook : mainBook;
-      const list = html`
-        <ul data-additional-book-href="${book.href}">
-          <li data-key="" aria-expanded="false">
-            <div>
-              <a>${book.title}</a>
-              <span>
-                <i class="icon">
-                  ${getIcon('chevron-right')}
-                </i>
-              </span>
-            </div>
-          </li>
-        </ul>`;
-
-      neighbor.insertAdjacentElement(position, list);
-      neighbor = list;
-    }
+    container.append(book.mainBook ? mainBook : html`
+      <ul data-additional-book-href="${book.href}">
+        <li data-key="" aria-expanded="false">
+          <div>
+            <a>${book.title}</a>
+            <span>
+              <i class="icon">
+                ${getIcon('chevron-right')}
+              </i>
+            </span>
+          </div>
+        </li>
+      </ul>`);
   });
 
   // load additional book data on block hover, replace toc list once loaded


### PR DESCRIPTION
Fix #104

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/public-sector
- After: https://book-order--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/public-sector
