### PR TITLE
fix: avoid overwriting state in pops, handle navigate events in sidenav

### DIFF
--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.js
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.js
@@ -107,6 +107,52 @@ function formatDate(date) {
   return `${month} ${day}, ${year}`;
 }
 
+function handleSPANavigation(state) {
+  const sidenav = document.querySelector('.block.sidenav .pan-sidenav');
+  const banner = sidenav.querySelector('div.banner');
+  const toc = sidenav.querySelector('div.toc-books');
+
+  // change current sidenav item
+  const prev = toc.querySelector('li.current');
+  if (prev) {
+    prev.classList.remove('current');
+  }
+
+  const next = toc.querySelector(`a[href="${state.siteHref}"]`);
+  if (next) {
+    next.closest('li').classList.add('current');
+  }
+
+  // update modified date
+  const dateEl = banner.querySelector('.book-detail-banner-info slot[name="date"]');
+  if (dateEl) {
+    dateEl.textContent = formatDate(state.info.lastModified);
+  }
+
+  // update dropdown links
+  const versionMenu = banner.querySelector('.version-dropdown-menu');
+  if (versionMenu) {
+    const curVers = store.version;
+    versionMenu.querySelectorAll('li:not(.active) a').forEach((a) => {
+      const nextVers = a.dataset.version;
+      const [prefix] = a.href.split(`/${nextVers}/`);
+      const suffix = state.siteHref.split(`/${curVers}/`).slice(1).join(`/${curVers}/`);
+      a.href = `${prefix}/${nextVers}/${suffix}`;
+    });
+  }
+
+  const langMenu = banner.querySelector('.language-dropdown-menu');
+  if (langMenu) {
+    const { lang: curLang } = document.documentElement;
+    langMenu.querySelectorAll('li:not(.active) a').forEach((a) => {
+      const nextLang = a.dataset.lang;
+      const [prefix] = a.href.split(`/${nextLang}/`);
+      const suffix = state.siteHref.split(`/${curLang}/`).slice(1).join(`/${curLang}/`);
+      a.href = `${prefix}/${nextLang}/${suffix}`;
+    });
+  }
+}
+
 async function navigateArticleSPA(ev) {
   if (!SPA_NAVIGATION) return;
 
@@ -129,51 +175,9 @@ async function navigateArticleSPA(ev) {
     return;
   }
 
-  store.emit('spa:navigate:article', { docHref, siteHref, ...res });
-
-  const sidenav = ev.target.closest('.pan-sidenav');
-  const banner = sidenav.querySelector('div.banner');
-  const toc = sidenav.querySelector('div.toc-books');
-
-  // change current sidenav item
-  const prev = toc.querySelector('li.current');
-  if (prev) {
-    prev.classList.remove('current');
-  }
-
-  const next = toc.querySelector(`a[href="${siteHref}"]`);
-  if (next) {
-    next.closest('li').classList.add('current');
-  }
-
-  // update modified date
-  const dateEl = banner.querySelector('.book-detail-banner-info slot[name="date"]');
-  if (dateEl) {
-    dateEl.textContent = formatDate(res.info.lastModified);
-  }
-
-  // update dropdown links
-  const versionMenu = banner.querySelector('.version-dropdown-menu');
-  if (versionMenu) {
-    const curVers = store.version;
-    versionMenu.querySelectorAll('li:not(.active) a').forEach((a) => {
-      const nextVers = a.dataset.version;
-      const [prefix] = a.href.split(`/${nextVers}/`);
-      const suffix = siteHref.split(`/${curVers}/`).slice(1).join(`/${curVers}/`);
-      a.href = `${prefix}/${nextVers}/${suffix}`;
-    });
-  }
-
-  const langMenu = banner.querySelector('.language-dropdown-menu');
-  if (langMenu) {
-    const { lang: curLang } = document.documentElement;
-    langMenu.querySelectorAll('li:not(.active) a').forEach((a) => {
-      const nextLang = a.dataset.lang;
-      const [prefix] = a.href.split(`/${nextLang}/`);
-      const suffix = siteHref.split(`/${curLang}/`).slice(1).join(`/${curLang}/`);
-      a.href = `${prefix}/${nextLang}/${suffix}`;
-    });
-  }
+  const state = { docHref, siteHref, ...res };
+  store.emit('spa:navigate:article', state);
+  handleSPANavigation(state);
 }
 
 /**
@@ -654,4 +658,8 @@ export default async function decorate(block) {
     initVersionDropdown(wrapper);
     initLanguagesDropdown(wrapper);
   });
+
+  if (SPA_NAVIGATION) {
+    store.on('spa:navigate:article', handleSPANavigation);
+  }
 }

--- a/prisma/prisma-cloud/scripts/scripts.js
+++ b/prisma/prisma-cloud/scripts/scripts.js
@@ -210,14 +210,21 @@ const store = new (class {
   initSPANavigation() {
     if (!SPA_NAVIGATION) return;
 
-    this.on('spa:navigate:article', (res) => {
-      window.history.pushState(res, '', res.siteHref);
+    let index = 0;
+    this.on('spa:navigate:article', (state) => {
+      if (state.index === index) return; // coming from popstate
+
+      window.history.pushState({ ...state, index }, '', state.siteHref);
+      index += 1;
     });
 
-    window.onpopstate = ({ state }) => {
+    window.addEventListener('popstate', (ev) => {
+      const { state } = ev;
       if (!state) return;
+      index = state.index || 0;
       this.emit('spa:navigate:article', state);
-    };
+      ev.preventDefault();
+    });
   }
 
   async getLocalizationInfo(book, product = this.product, version = this.version) {


### PR DESCRIPTION
Fix #128

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/authentication/assign-roles
- After: https://maxed-128--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/authentication/assign-roles
