### PR TITLE
sidenav, spa loading fixes

### DIFF
--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.js
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.js
@@ -562,10 +562,18 @@ function renderTOC(container, book, expand, replace) {
       }
     }
 
-    // Scroll to current
-    requestAnimationFrame(() => {
-      container.scrollTop = currentLi.offsetTop;
-    });
+    // wait until list expansion is rendered (up to 1s), then scroll to current
+    (async () => {
+      let count = 0;
+      while (currentLi.clientHeight === 0 && count < 100) {
+        // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+        await new Promise((r) => setTimeout(r, 10));
+        count += 1;
+      }
+      requestAnimationFrame(() => {
+        container.scrollTop = currentLi.offsetTop;
+      });
+    })();
   }
 }
 

--- a/prisma/prisma-cloud/scripts/scripts.js
+++ b/prisma/prisma-cloud/scripts/scripts.js
@@ -88,6 +88,10 @@ function getBranch() {
   return null;
 }
 
+export function siteToDocURL(siteUrl) {
+  return `${PATH_PREFIX}/docs${siteUrl.substring(PATH_PREFIX.length)}`;
+}
+
 /**
  * Sets the branch search param to a given url
  *
@@ -210,7 +214,20 @@ const store = new (class {
   initSPANavigation() {
     if (!SPA_NAVIGATION) return;
 
-    let index = 0;
+    // replace first state with the first loaded article
+    this.once('article:fetched', (data) => {
+      const siteHref = window.location.href.substring(window.location.origin.length);
+      const docHref = siteToDocURL(siteHref);
+      window.history.replaceState({
+        ...data,
+        index: 0,
+        siteHref,
+        docHref,
+      }, '', siteHref);
+    });
+
+    // handle state updates, ignore if initiated by store
+    let index = 1;
     this.on('spa:navigate:article', (state) => {
       if (state.index === index) return; // coming from popstate
 
@@ -220,8 +237,7 @@ const store = new (class {
 
     window.addEventListener('popstate', (ev) => {
       const { state } = ev;
-      if (!state) return;
-      index = state.index || 0;
+      index = state.index;
       this.emit('spa:navigate:article', state);
       ev.preventDefault();
     });
@@ -619,7 +635,7 @@ export async function loadArticle(href) {
   if (!resp.ok) return resp;
   try {
     const lastModified = resp.headers.get('last-modified') !== 'null' ? new Date(resp.headers.get('last-modified')) : new Date();
-    return {
+    const data = {
       ok: true,
       status: resp.status,
       info: {
@@ -627,6 +643,8 @@ export async function loadArticle(href) {
       },
       html: await resp.text(),
     };
+    store.emit('article:fetched', data);
+    return data;
   } catch (e) {
     console.error('failed to parse article: ', e);
     return {

--- a/types/Events.d.ts
+++ b/types/Events.d.ts
@@ -16,6 +16,7 @@ import { BookDefinition } from "./Book";
 export interface EventMap {
   'delayed:loaded': void;
   'book:loaded': BookDefinition;
+  'article:fetched': ArticleResponse;
   'article:loaded': ArticleInfo;
   'header:loaded': void;
   'blocks:loaded': void;


### PR DESCRIPTION
- wait for list expansion before scrolling sidenav item into view
  - previously a race condition occasionally made the scroll not happen
- save initial state on article fetch for last popstate
  - previously the first page visited in a new session could not be navigated to via "back" button

Fix #62

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/vulnerability-management/registry-scanning/scan-google-artifact-registry
- After: https://maxed-spa--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/vulnerability-management/registry-scanning/scan-google-artifact-registry
