### PR TITLE
fix: unset img width/height in article block

### DIFF
--- a/prisma/prisma-cloud/blocks/article/article.css
+++ b/prisma/prisma-cloud/blocks/article/article.css
@@ -178,6 +178,8 @@
 .pan-article .book-content img {
     margin: 15px auto;
     display: block;
+    width: unset;
+    height: unset;
 }
 
 .pan-article .book-content pre {


### PR DESCRIPTION
Fix #139

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/welcome/test-asciidoc
- After: https://maxed-fixes--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/welcome/test-asciidoc
