### PR TITLE
fix: use docs origin for relative fragment paths

### DIFF
--- a/prisma/prisma-cloud/blocks/fragment/fragment.js
+++ b/prisma/prisma-cloud/blocks/fragment/fragment.js
@@ -6,6 +6,7 @@
 
 import {
   BRANCH_ORIGIN,
+  DOCS_ORIGINS,
   decorateMain,
   isValidDocsURL,
   isValidWebURL,
@@ -90,7 +91,11 @@ export default async function decorate(block) {
   const fromDocs = block.classList.contains('docs');
 
   if (store.branch) {
-    const url = new URL(href);
+    const url = new URL(
+      !href.startsWith('/') && !href.startsWith('.')
+        ? href
+        : `${DOCS_ORIGINS[store.env]}${href}`,
+    );
     setBranch(url, store.branch, true);
     href = url.toString();
   }


### PR DESCRIPTION
Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/agentless-scanning/onboard-accounts/onboard-azure?branch=ian/fix-include
- After: https://maxed-fixes-2--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/compute/pcee/admin-guide/agentless-scanning/onboard-accounts/onboard-azure?branch=ian/fix-include
