### PR TITLE
Add legacy product/doc-set

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -8,6 +8,7 @@ folders:
   /prisma/prisma-cloud/en/cns/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/en/prisma-cloud-ag/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/en/prisma-cloud-rql-ref/: /prisma/prisma-cloud/en/product/book-default
+  /prisma/prisma-cloud/en/classic/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/jp/compute/: /prisma/prisma-cloud/jp/product/book-default
   /prisma/prisma-cloud/jp/code-security/: /prisma/prisma-cloud/jp/product/book-default
   /prisma/prisma-cloud/jp/cspm/: /prisma/prisma-cloud/jp/product/book-default


### PR DESCRIPTION
We'll publish all legacy books as a doc set, under the product key "classic".

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-classic--prisma-cloud-docs-website--hlxsites.hlx.page/
