### PR TITLE
Remove prisma-cloud-ag and prisma-cloud-rql-ref products

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -6,8 +6,6 @@ folders:
   /prisma/prisma-cloud/en/code-security/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/en/cspm/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/en/cns/: /prisma/prisma-cloud/en/product/book-default
-  /prisma/prisma-cloud/en/prisma-cloud-ag/: /prisma/prisma-cloud/en/product/book-default
-  /prisma/prisma-cloud/en/prisma-cloud-rql-ref/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/en/classic/: /prisma/prisma-cloud/en/product/book-default
   /prisma/prisma-cloud/jp/compute/: /prisma/prisma-cloud/jp/product/book-default
   /prisma/prisma-cloud/jp/code-security/: /prisma/prisma-cloud/jp/product/book-default


### PR DESCRIPTION
These were being used for legacy books, but we decided to combine all legacy books into a single doc set.

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-cleanup--prisma-cloud-docs-website--hlxsites.hlx.page/
