### PR TITLE
various fixes

### DIFF
--- a/prisma/prisma-cloud/blocks/fragment/fragment.js
+++ b/prisma/prisma-cloud/blocks/fragment/fragment.js
@@ -42,6 +42,8 @@ async function loadFragment(path, fromDocs) {
     const url = new URL(href, store.branch ? BRANCH_ORIGIN : store.docsOrigin);
     url.pathname += '.plain.html';
     href = url.toString();
+  } else if (!href.endsWith('.plain.html')) {
+    href = `${href}.plain.html`;
   }
 
   const resp = await fetch(href);

--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.js
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.js
@@ -637,7 +637,7 @@ function bookToList(book) {
         }
       }
     };
-    chapter.children.forEach((topic) => processTopic(topic));
+    (chapter.children || []).forEach((topic) => processTopic(topic));
   });
 
   return root;

--- a/prisma/prisma-cloud/blocks/sidenav/sidenav.js
+++ b/prisma/prisma-cloud/blocks/sidenav/sidenav.js
@@ -745,7 +745,7 @@ function initAdditionalBooks(block, container) {
     async () => {
       container.querySelectorAll('[data-additional-book-href]').forEach((list) => {
         store
-          .fetchJSON(list.dataset.additionalBookHref, ['default', 'chapters', 'topics'])
+          .fetchJSON(list.dataset.additionalBookHref, ['default', 'chapters', 'topics'], { limit: 10000 })
           .then((data) => {
             const sorted = sortBook(data);
             renderTOC(container, sorted, false, list);

--- a/prisma/prisma-cloud/scripts/scripts.js
+++ b/prisma/prisma-cloud/scripts/scripts.js
@@ -546,7 +546,7 @@ export function render(template, fragment) {
  */
 export async function loadBook(href) {
   assertValidDocsURL(href);
-  return store.fetchJSON(href, ['default', 'chapters', 'topics']);
+  return store.fetchJSON(href, ['default', 'chapters', 'topics'], { limit: 10000 });
 }
 
 /**

--- a/prisma/prisma-cloud/scripts/scripts.js
+++ b/prisma/prisma-cloud/scripts/scripts.js
@@ -308,8 +308,9 @@ const store = new (class {
   /**
    * @param {string} path
    * @param {string|string[]} [sheets]
+   * @param {Record<string, string|number>} [filters]
    */
-  async fetchJSON(path, sheets) {
+  async fetchJSON(path, sheets, filters = {}) {
     let url;
     try {
       url = new URL(`${path}.json`);
@@ -322,6 +323,12 @@ const store = new (class {
       sheets = Array.isArray(sheets) ? [...sheets] : [sheets];
       sheets.sort().forEach((sheet) => {
         url.searchParams.append('sheet', sheet);
+      });
+    }
+
+    if (filters) {
+      Object.entries(filters).forEach(([filter, value]) => {
+        url.searchParams.append(filter, value);
       });
     }
 


### PR DESCRIPTION
- allow empty children in sidenav book sort
- load `.plain.html` for all fragments, including paths without origins
- set `limit` query param for fetchJSON calls for book data to 10k

fix #157 

Test URLs:

Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/enterprise-edition/use-cases/visibility-control/use-case1
After: https://maxed-fixes-2--prisma-cloud-docs-website--hlxsites.hlx.page/prisma/prisma-cloud/en/enterprise-edition/use-cases/visibility-control/use-case1