### PR TITLE
fix: hide carousel overflow by default

### DIFF
--- a/prisma/prisma-cloud/blocks/card-carousel/card-carousel.css
+++ b/prisma/prisma-cloud/blocks/card-carousel/card-carousel.css
@@ -5,7 +5,7 @@
 }
 
 .card-carousel .splide__track {
-  overflow: visible;
+  overflow: hidden;
 }
 
 .card-carousel .card {


### PR DESCRIPTION
Per request, hide the carousel overflow for landing pages

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/en
- After: https://redesign-fixes--prisma-cloud-docs-website--hlxsites.hlx.page/en
