### PR TITLE
PCDTUS-49: Fix entry in search drop-down menu

### DIFF
--- a/prisma/prisma-cloud/blocks/search-bar/search-bar.js
+++ b/prisma/prisma-cloud/blocks/search-bar/search-bar.js
@@ -75,7 +75,7 @@ export class SearchBar extends HTMLElement {
 
   init() {
     const booknameMeta = getMetadata('book-name');
-    const productMeta = getMetadata('product');
+    const productMeta = getMetadata('docset-title');
     const docsetMeta = getMetadata('docset-id');
 
     const appendDropdown = this.querySelector('.dropdown-content');

--- a/prisma/prisma-cloud/blocks/search-bar/search-bar.js
+++ b/prisma/prisma-cloud/blocks/search-bar/search-bar.js
@@ -105,11 +105,11 @@ export class SearchBar extends HTMLElement {
       if (!booknameMeta) {
         this.querySelector('.coveo-dropdown-item.selected').classList.remove('selected');
         docSetOption.classList.add('selected');
-        this.querySelector('.dropbtn').textContent = `All ${productMeta} books`;
+        this.querySelector('.dropbtn').textContent = `All ${productMeta} Books`;
       }
-      docSetOption.setAttribute('data-label', `All ${productMeta} books`);
+      docSetOption.setAttribute('data-label', `All ${productMeta} Books`);
       docSetOption.setAttribute('data-value', `@td_docsetid==("${docsetMeta}")`);
-      docSetOption.append(`All ${productMeta} books`);
+      docSetOption.append(`All ${productMeta} Books`);
       appendDropdown.prepend(docSetOption);
     }
     if (booknameMeta) {


### PR DESCRIPTION
Per Request, Before search bar dropdown values were taken from meta tag 'product', as per the request changed metatag to 'docset-title'
Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.live/prisma/prisma-cloud/en/enterprise-edition/use-cases/secure-the-infrastructure/gain-visibility-into-your-cloud-estate
- After: https://coveo-uat--prisma-cloud-docs-website--hlxsites.hlx.live/prisma/prisma-cloud/en/enterprise-edition/use-cases/secure-the-infrastructure/gain-visibility-into-your-cloud-estate
