### PR TITLE
Fix: Hide version selector when there are no versions

### DIFF
--- a/blocks/article/article.js
+++ b/blocks/article/article.js
@@ -119,8 +119,6 @@ function initVersionDropdown(wrapper) {
   const versionButton = versionsDropdown.querySelector('.version-button');
   const versionsDropdownMenuContainer = versionsContainer.querySelector('.version-dropdown-menu');
   const curVersionKey = getMetadata('version');
-  console.log('curVersionKey: ', curVersionKey);
-  console.log('store.product: ', store.product);
   if (!store.product || curVersionKey === 'not-applicable' || !curVersionKey) {
     versionsContainer.remove();
     return;
@@ -149,7 +147,6 @@ function initVersionDropdown(wrapper) {
         store.product,
       );
 
-      console.log('json: ', json);
       if (!json) return;
 
       const curVersion = json.data.find((row) => row.Key === curVersionKey);

--- a/blocks/article/article.js
+++ b/blocks/article/article.js
@@ -119,8 +119,9 @@ function initVersionDropdown(wrapper) {
   const versionButton = versionsDropdown.querySelector('.version-button');
   const versionsDropdownMenuContainer = versionsContainer.querySelector('.version-dropdown-menu');
   const curVersionKey = getMetadata('version');
-
-  if (!store.product || curVersionKey === 'not-applicable') {
+  console.log('curVersionKey: ', curVersionKey);
+  console.log('store.product: ', store.product);
+  if (!store.product || curVersionKey === 'not-applicable' || !curVersionKey) {
     versionsContainer.remove();
     return;
   }
@@ -148,6 +149,7 @@ function initVersionDropdown(wrapper) {
         store.product,
       );
 
+      console.log('json: ', json);
       if (!json) return;
 
       const curVersion = json.data.find((row) => row.Key === curVersionKey);

--- a/blocks/sidenav/sidenav.js
+++ b/blocks/sidenav/sidenav.js
@@ -230,7 +230,6 @@ const initProductDropdown = async (wrapper) => {
   });
 
   const json = await store.fetchJSON(`${window.location.origin}${PATH_PREFIX}/products`);
-  console.log('product json: ',  json);
 
   if (!json) return;
 

--- a/blocks/sidenav/sidenav.js
+++ b/blocks/sidenav/sidenav.js
@@ -230,6 +230,7 @@ const initProductDropdown = async (wrapper) => {
   });
 
   const json = await store.fetchJSON(`${window.location.origin}${PATH_PREFIX}/products`);
+  console.log('product json: ',  json);
 
   if (!json) return;
 


### PR DESCRIPTION
Only some books have versions. Most don’t. On pages for books that don’t have version. the version drop-down shouldn’t be shown.

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.live/en/enterprise-edition/content-collections/get-started/welcome-to-prisma-cloud
- After: https://fix-version-dd--prisma-cloud-docs-website--hlxsites.hlx.live/en/enterprise-edition/content-collections/get-started/welcome-to-prisma-cloud
