### PR TITLE
Fixes for table headers and left nav arrow styling

### DIFF
--- a/blocks/sidenav/sidenav.js
+++ b/blocks/sidenav/sidenav.js
@@ -739,8 +739,22 @@ function initAdditionalBooks(block, container) {
             <li data-key="" aria-expanded="false">
               <div>
                 <a>${book.title}</a>
-                <span>
-                  <i class="icon"> ${getIcon('chevron-right')} </i>
+                <span class="icon-toggle">
+                <svg
+                    class="icon icon-arrow"
+                    focusable="false"
+                    aria-label="Expand"
+                    version="1.1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="32"
+                    height="32"
+                    viewBox="0 0 32 32"
+                  >
+                    <title>Right Arrow</title>
+                    <path
+                      d="M7.527 0.669c-0.893 0.893-0.893 2.34 0 3.232l11.29 11.29c0.446 0.446 0.446 1.17 0 1.616l-11.29 11.29c-0.893 0.893-0.893 2.34 0 3.232s2.34 0.893 3.232 0l13.714-13.714c0.893-0.893 0.893-2.34 0-3.232l-13.714-13.714c-0.893-0.893-2.34-0.893-3.232 0z"
+                    ></path>
+                  </svg>
                 </span>
               </div>
             </li>

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -40,19 +40,19 @@
 }
 
 .table thead th:first-child,
-.table table > tbody:first-child tr:first-child td:first-child {
+.table table > colgroup + tbody tr:first-child td:first-child {
   border-top-left-radius: var(--table-border-radius);
   border-left: 1px solid var(--table-border-color);
 }
 
 .table thead th:last-child,
-.table table > tbody:first-child tr:first-child td:last-child {
+.table table > colgroup + tbody tr:first-child td:last-child {
   border-top-right-radius: var(--table-border-radius);
   border-right: 1px solid var(--table-border-color);
 }
 
 /* Handle use case for when there's no actual table header */
-.table table > tbody:first-child tr:first-child td {
+.table table > colgroup + tbody tr:first-child td {
   border-top: 1px solid var(--table-border-color);
 }
 


### PR DESCRIPTION
Update styling for tables without headers and fix left nav arrow styles for lazy loaded books

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.live/en/enterprise-edition/rn/prisma-cloud-release-info/features-introduced-in-2023/features-introduced-in-october-2023#new-features1
- After: https://fixes-styling--prisma-cloud-docs-website--hlxsites.hlx.live/en/enterprise-edition/rn/prisma-cloud-release-info/features-introduced-in-2023/features-introduced-in-october-2023#new-features1

- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.live/en/enterprise-edition/rn/prisma-cloud-release-info/features-introduced-in-2023/features-introduced-in-2023
- After: https://fixes-styling--prisma-cloud-docs-website--hlxsites.hlx.live/en/enterprise-edition/rn/prisma-cloud-release-info/features-introduced-in-2023/features-introduced-in-2023
