### PR TITLE
fix: allow colspans on any cell

### DIFF
--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -13,7 +13,10 @@ function extractColWidths(block) {
   }
 
   const cols = firstCol.nextElementSibling.textContent.split(',');
+  console.log('extractColWidths cols: ', cols);
   const maxVal = parseInt([...cols].sort().reverse()[0], 10);
+  console.log('extractColWidths maxVal: ', maxVal);
+
   const widths = cols.map((swid) => Math.round((100 * parseInt(swid, 10)) / maxVal));
   firstRow.remove();
   return widths;
@@ -29,7 +32,9 @@ function extractColSpans(block) {
     return [];
   }
 
-  const cols = firstCol.nextElementSibling.textContent.split(',');
+  const cols = firstCol.nextElementSibling.textContent.split(';').map((row) => row.split(','));
+  console.log('extractColSpans cols: ', cols);
+
   firstRow.remove();
   return cols;
 }
@@ -111,11 +116,12 @@ export default async function decorate(block) {
     const head = rows.shift();
     if (!head) return;
 
+    const spans = colSpans.shift() || [];
     const cells = [...head.querySelectorAll(':scope > div')];
     const thead = html` <table>
       <thead>
         <tr>
-          ${cells.map((cell, i) => `<th${colSpans[i] ? ` colspan="${colSpans[i]}"` : ''}>${cell.innerHTML}</th>`).join('\n')}
+          ${cells.map((cell, i) => `<th${spans[i] ? ` colspan="${spans[i]}"` : ''}>${cell.innerHTML}</th>`).join('\n')}
         </tr>
       </thead>
     </table>`.firstElementChild;
@@ -128,10 +134,12 @@ export default async function decorate(block) {
   table.appendChild(tbody);
 
   rows.forEach((row) => {
+    const spans = colSpans.shift() || [];
     const cells = [...row.querySelectorAll(':scope > div')];
+
     const tr = html` <table>
       <tr>
-        ${cells.map((cell) => `<td>${cell.innerHTML}</td>`).join('\n')}
+        ${cells.map((cell, i) => `<td${spans[i] ? ` colspan="${spans[i]}"` : ''}>${cell.innerHTML}</td>`).join('\n')}
       </tr>
     </table>`.firstElementChild.firstElementChild;
     tbody.appendChild(tr);

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -13,10 +13,7 @@ function extractColWidths(block) {
   }
 
   const cols = firstCol.nextElementSibling.textContent.split(',');
-  console.log('extractColWidths cols: ', cols);
   const maxVal = parseInt([...cols].sort().reverse()[0], 10);
-  console.log('extractColWidths maxVal: ', maxVal);
-
   const widths = cols.map((swid) => Math.round((100 * parseInt(swid, 10)) / maxVal));
   firstRow.remove();
   return widths;
@@ -33,8 +30,6 @@ function extractColSpans(block) {
   }
 
   const cols = firstCol.nextElementSibling.textContent.split(';').map((row) => row.split(','));
-  console.log('extractColSpans cols: ', cols);
-
   firstRow.remove();
   return cols;
 }


### PR DESCRIPTION
- change worker output to provide colspans of all cells (unless they're all `1`)
  - format: `<row1cell1>,<row1cell2>,...<row1cellN>;<row2cell1>,<row2cell2>,...<row2cellN>;<rowNcell1>,...<rowNcellN>`
- change table block to use those spans

ref: https://github.com/hlxsites/prisma-cloud-docs/pull/120

Fix #200

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/en/enterprise-edition/content-collections/dashboards/dashboards-get-started
- After: https://maxed-tables--prisma-cloud-docs-website--hlxsites.hlx.page/en/enterprise-edition/content-collections/dashboards/dashboards-get-started
