### PR TITLE
fix: hide carousel overflow by default

### DIFF
--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -5,7 +5,7 @@
 }
 
 .card-carousel .splide__track {
-  overflow: visible;
+  overflow: hidden;
 }
 
 .card-carousel .card {


### PR DESCRIPTION
Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-carousel-fix--prisma-cloud-docs-website--hlxsites.hlx.page/
