### PR TITLE
console warnings

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -221,6 +221,10 @@ const store = new (class {
         return book;
       });
 
+    if (!this.mainBook) {
+      console.warn('page configured as book, but missing main book; possible metadata sheet issue');
+    }
+
     // exclude main book from additionalBooks
     this.additionalBooks = this.allBooks.filter((b) => !b.mainBook);
   }


### PR DESCRIPTION
- add warning when `store.mainBook` is undefined, but the page is configured as a `book` template