### PR TITLE
fix: construct working landing page links in articles

### DIFF
--- a/blocks/article/article.js
+++ b/blocks/article/article.js
@@ -502,7 +502,7 @@ async function renderContent(block, res, rerender = false) {
   // Add link to division landing
   const backHomeLink = block.querySelector('.back-home a');
   if (backHomeLink) {
-    const locale = window.location.pathname.split('/')[3];
+    const locale = window.location.pathname.split('/')[0];
     const divisionLandingUrl = `${window.location.origin}${window.hlx.codeBasePath}/${locale}`;
     backHomeLink.setAttribute('href', divisionLandingUrl);
   }


### PR DESCRIPTION
The "Prisma Cloud TechDocs" logo/text in the top left of the article pane should take you to the main landing page.

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-fix-article-back-home--prisma-cloud-docs-website--hlxsites.hlx.page/
