### PR TITLE
fix: properly construct product selector URLs

### DIFF
--- a/blocks/sidenav/sidenav.js
+++ b/blocks/sidenav/sidenav.js
@@ -240,7 +240,7 @@ const initProductDropdown = async (wrapper) => {
     curProductBtn.textContent = curProduct.Product;
   }
 
-  const makeHref = (url) => `${PATH_PREFIX}/${lang}${url ? `${url}/` : ''}`;
+  const makeHref = (url) => `${PATH_PREFIX}/${lang}${url ? `${url}` : ''}`;
 
   const newProducts = json.data
     .map((row) => {


### PR DESCRIPTION
The sidenav code added a forward slash (`/`) to the end of URLs in the product spreadsheet. The code should use the URLs as-is from the product spreadsheet

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-fix-product-switcher--prisma-cloud-docs-website--hlxsites.hlx.page/
