### PR TITLE
fix: disable language selector for now

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -10,6 +10,7 @@ import {
   isTouchDevice,
   parseFragment,
   render,
+  LANGUAGE_SELECTOR_ENABLED,
 } from '../../scripts/scripts.js';
 
 // <search-bar data-default-option="all"></search-bar>
@@ -642,7 +643,10 @@ export default async function decorate(block) {
   }
 
   // load custom elements
-  import('../language-selector/language-selector.js');
+
+  if (LANGUAGE_SELECTOR_ENABLED) {
+    import('../language-selector/language-selector.js');
+  }
   import('../search-bar/search-bar.js');
   import('../theme-toggle/theme-toggle.js');
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -672,18 +672,6 @@ export function loadFooter(footer) {
 }
 
 /**
- * Loads a block named 'language selector' just above the footer
- * @param footer footer element
- * @returns {Promise}
- */
-export function loadLanguageSelector(footer) {
-  const languageSelectorBlock = buildBlock('language-selector', '');
-  footer.append(languageSelectorBlock);
-  decorateBlock(languageSelectorBlock);
-  return loadBlock(languageSelectorBlock);
-}
-
-/**
  * Setup block utils.
  */
 export function setup() {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,7 +12,6 @@ import {
   loadCSS,
   loadFooter,
   loadHeader,
-  loadLanguageSelector,
   sampleRUM,
   toClassName,
   updateSectionsStatus,
@@ -24,6 +23,7 @@ polyfill();
 
 const range = document.createRange();
 
+export const LANGUAGE_SELECTOR_ENABLED = false;
 export const BRANCH_ORIGIN = 'https://prisma-cloud-docs-production.adobeaem.workers.dev';
 // export const BRANCH_ORIGIN = 'http://127.0.0.1:3001';
 
@@ -1013,6 +1013,18 @@ export function addFavIcon(href) {
 }
 
 /**
+ * Loads a block named 'language selector' just above the footer
+ * @param footer footer element
+ * @returns {Promise}
+ */
+function loadLanguageSelector(footer) {
+  const languageSelectorBlock = buildBlock('language-selector', '');
+  footer.append(languageSelectorBlock);
+  decorateBlock(languageSelectorBlock);
+  return loadBlock(languageSelectorBlock);
+}
+
+/**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
  */
@@ -1026,7 +1038,9 @@ async function loadLazy(doc) {
   if (hash && element) element.scrollIntoView();
 
   loadHeader(doc.querySelector('header'));
-  loadLanguageSelector(doc.querySelector('footer'));
+  if (LANGUAGE_SELECTOR_ENABLED) {
+    loadLanguageSelector(doc.querySelector('footer'));
+  }
   loadFooter(doc.querySelector('footer'));
 
   if (doc.body.classList.contains('book')) {


### PR DESCRIPTION
- adds toggle constant for language selector element in scripts.js, set to `false` for now

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/en
- After: https://maxed-lang-selector--prisma-cloud-docs-website--hlxsites.hlx.page/en
