### PR TITLE
Enhance how products work with localized content

### DIFF
--- a/blocks/sidenav/sidenav.js
+++ b/blocks/sidenav/sidenav.js
@@ -198,6 +198,13 @@ async function navigateArticleSPA(ev) {
   handleSPANavigation(state);
 }
 
+function disableProductButton(button) {
+  const buttonDownArrow = button.querySelector('.icon-container');
+
+  button.setAttribute('disabled', true);
+  buttonDownArrow.setAttribute('hidden', true);
+}
+
 /**
  * Add product dropdown
  * @param {Element} wrapper
@@ -267,13 +274,6 @@ const initProductDropdown = async (wrapper) => {
     disableProductButton(productButton);
   }
 };
-
-function disableProductButton(button) {
-  const buttonDownArrow = button.querySelector('.icon-container');
-
-  button.setAttribute('disabled', true);
-  buttonDownArrow.setAttribute('hidden', true);
-}
 
 /**
  * Add version dropdown

--- a/blocks/sidenav/sidenav.js
+++ b/blocks/sidenav/sidenav.js
@@ -229,7 +229,7 @@ const initProductDropdown = async (wrapper) => {
     }
   });
 
-  const json = await store.fetchJSON(`${window.location.origin}${PATH_PREFIX}/products`);
+  const json = await store.fetchJSON(`${window.location.origin}${PATH_PREFIX}/${lang}/products`);
 
   if (!json) return;
 
@@ -261,8 +261,19 @@ const initProductDropdown = async (wrapper) => {
     })
     .filter((item) => !!item);
 
-  productsDropdownMenu.append(...newProducts);
+  if (newProducts.length) {
+    productsDropdownMenu.append(...newProducts);
+  } else {
+    disableProductButton(productButton);
+  }
 };
+
+function disableProductButton(button) {
+  const buttonDownArrow = button.querySelector('.icon-container');
+
+  button.setAttribute('disabled', true);
+  buttonDownArrow.setAttribute('hidden', true);
+}
 
 /**
  * Add version dropdown


### PR DESCRIPTION
- Refactor the products spreadsheet - Currently, there's one products sheet system-wide. Instead, use one products sheet per language dir. This way, if only 1 of X products is translated, you can limit what's shown in the product selector drop-down menu. For example, en has three products (Enterprise Edition, Compute Edition, and Classic), but we only translated one product into jp (Enterprise Edition)
- Handle the case when there's only a single product (e.g. jp only has Enterprise Edition). In this case, disable the product drop-down menu. Clicking shouldn't do anything since there aren't any other products to switch to.

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-products-localization--prisma-cloud-docs-website--hlxsites.hlx.page/
