### PR TITLE
Add optional announcement banner

### DIFF
--- a/blocks/article/article.css
+++ b/blocks/article/article.css
@@ -270,6 +270,23 @@ article [data-docs-heading] span {
   align-items: center;
 }
 
+.announcement {
+  padding-bottom: var(--spacing--10);
+}
+
+.announcement p {
+  color: white;
+  background-color: #aa0006;
+  margin: 0;
+  padding: 15px 10px;
+}
+
+.announcement a {
+  color: white;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
 .article-actions {
   align-items: center;
   display: flex;

--- a/blocks/article/article.js
+++ b/blocks/article/article.js
@@ -48,7 +48,8 @@ const TEMPLATE = /* html */ `
               <i class="icon-share-alt"></i>
           </a>
       </div>
-      </div>
+    </div>
+    <slot name="announcement"></slot>     
       <div class="banner contain">
           <div class="banner-inner">
             <span class="banner-inner-desktop">
@@ -401,6 +402,16 @@ async function renderContent(block, res, rerender = false) {
 
   block.classList.remove(`source-${isGdoc ? 'adoc' : 'gdoc'}`);
   block.classList.add(`source-${isGdoc ? 'gdoc' : 'adoc'}`);
+
+  // Set announcement
+  const announceStr = getMetadata('announcement');
+  if (announceStr) {
+    const announce = document.createElement('div');
+    announce.classList.add('announcement');
+    announce.innerHTML = announceStr;
+    announce.setAttribute('slot', 'announcement');
+    fragment.append(announce);
+  }
 
   if (articleFound) {
     const { html, info } = res;


### PR DESCRIPTION
Add the ability to show an optional announcement banner at the top of any page. The banner is configurable via the metadata sheet.

In the metadata sheet, there's an announcement column. If the page being rendered has an announcement (an HTML string), the string is taken from the metadata and rendered in a red box at the top of the page.

There aren't many configuration options for announcements yet. The goal was to get this out as quickly as possible because we have old pages that customers still mistakenly reference, but which PM isn't ready to pull down yet. We want to able to quickly redirect customers to the right place.


Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-banner--prisma-cloud-docs-website--hlxsites.hlx.page/
