### PR TITLE
Style numbered lists in articles

### DIFF
--- a/blocks/article/article.css
+++ b/blocks/article/article.css
@@ -443,6 +443,18 @@ article [data-docs-heading] span {
   word-break: break-word;
 }
 
+.pan-article .book-content ol {
+  list-style-type: decimal;
+}
+
+.pan-article .book-content ol ol {
+  list-style-type: lower-alpha;
+}
+
+.pan-article .book-content ol ol ol {
+  list-style-type: lower-roman;
+}
+
 .pan-article .book-content pre {
   display: block;
   margin: var(--spacing--6) 0;


### PR DESCRIPTION
Numbered listed and nested numbered lists aren't styled when ingested from Gdocs. Numbered lists count from in integers startingfrom 1. Nested numbered lists (all levels) also count in integers starting from 1. Level 1 nesting should count in lowercase alpha. Level 2 nesting should count in lowercase roman numerals.

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-style-numbered-lists--prisma-cloud-docs-website--hlxsites.hlx.page/
