### PR TITLE
Adds CSS for highlighted text in search suggestions

### DIFF
--- a/blocks/search-bar/search-bar.css
+++ b/blocks/search-bar/search-bar.css
@@ -340,6 +340,14 @@ search-bar {
   margin-bottom: var(--spacing--1);
 }
 
+.search-bar .magic-box .magic-box-suggestions .magic-box-suggestion .coveo-omnibox-hightlight {
+  color: var(--search-text-color);
+}
+
+.search-bar .magic-box .magic-box-suggestions .magic-box-suggestion .coveo-omnibox-hightlight2 {
+  color: var(--search-text-color);
+}
+
 .search-bar .dropdown-content .coveo-dropdown-hero-search {
   display: none;
 }


### PR DESCRIPTION
Currently, there is no relevant CSS rule for dark mode, and the highlighted bits of the search suggestions aren't visible. This commit adds explicit rules.

Test URLs:
- Before: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/
- After: https://ian-fix-search-suggestions--prisma-cloud-docs-website--hlxsites.hlx.page/
